### PR TITLE
Validate perf bundle gate rollout

### DIFF
--- a/.github/workflows/perf-enforced.yml
+++ b/.github/workflows/perf-enforced.yml
@@ -12,8 +12,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -29,8 +29,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -45,8 +45,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -61,8 +61,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2
       - run: k6 run tests/perf/api.k6.js --summary-export=.perf-results/api-summary.json
         env:

--- a/.github/workflows/perf-enforced.yml
+++ b/.github/workflows/perf-enforced.yml
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install PostgreSQL client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - run: psql "${{ vars.PERF_DATABASE_URL }}" -f scripts/perf/db/check-pg-stat.sql

--- a/.github/workflows/perf-enforced.yml
+++ b/.github/workflows/perf-enforced.yml
@@ -1,0 +1,96 @@
+name: perf-enforced
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main, master]
+
+jobs:
+  perf-bundle:
+    if: ${{ vars.PERF_PROFILE == 'production' && vars.PERF_BUNDLE_BASELINE_READY == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: npm --prefix apps/desktop/ui run build
+      - run: node scripts/perf/bundle-report.mjs
+      - run: node scripts/perf/compare-metric.mjs .perf-baselines/bundle.json .perf-results/bundle.json totalBytes 0.08
+
+  perf-build:
+    if: ${{ vars.PERF_PROFILE == 'production' && vars.PERF_BUILD_BASELINE_READY == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: node scripts/perf/measure-build-time.mjs
+      - run: node scripts/perf/compare-metric.mjs .perf-baselines/build-time.json .perf-results/build-time.json buildMs 0.15
+
+  perf-assets:
+    if: ${{ vars.PERF_PROFILE == 'production' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: npm --prefix apps/desktop/ui run build
+      - run: ASSET_MAX_BYTES=250000 bash scripts/perf/check-assets.sh
+
+  perf-memory:
+    if: ${{ vars.PERF_PROFILE == 'production' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: MEMORY_MAX_DELTA_MB=5 node --expose-gc scripts/perf/memory-smoke.mjs
+
+  perf-api:
+    if: ${{ vars.PERF_PROFILE == 'production' && vars.PERF_BASE_URL != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2
+      - run: k6 run tests/perf/api.k6.js --summary-export=.perf-results/api-summary.json
+        env:
+          BASE_URL: ${{ vars.PERF_BASE_URL }}
+          API_P95_MS: "250"
+          API_P99_MS: "700"
+
+  perf-db:
+    if: ${{ vars.PERF_PROFILE == 'production' && vars.PERF_DATABASE_URL != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - run: psql "${{ vars.PERF_DATABASE_URL }}" -f scripts/perf/db/check-pg-stat.sql

--- a/.github/workflows/perf-foundation.yml
+++ b/.github/workflows/perf-foundation.yml
@@ -82,7 +82,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install PostgreSQL client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - run: psql "${{ vars.PERF_DATABASE_URL }}" -f scripts/perf/db/check-pg-stat.sql

--- a/.github/workflows/perf-foundation.yml
+++ b/.github/workflows/perf-foundation.yml
@@ -11,8 +11,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -26,8 +26,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -40,8 +40,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -55,8 +55,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 20
           cache: npm
@@ -70,7 +70,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2
       - run: k6 run tests/perf/api.k6.js --summary-export=.perf-results/api-summary.json
         env:

--- a/.github/workflows/perf-foundation.yml
+++ b/.github/workflows/perf-foundation.yml
@@ -1,0 +1,88 @@
+name: perf-foundation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, master]
+
+jobs:
+  perf-bundle:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: npm --prefix apps/desktop/ui run build
+      - run: node scripts/perf/bundle-report.mjs
+
+  perf-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: node scripts/perf/measure-build-time.mjs
+
+  perf-assets:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: npm --prefix apps/desktop/ui run build
+      - run: bash scripts/perf/check-assets.sh
+
+  perf-memory:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: apps/desktop/ui/package-lock.json
+      - run: npm --prefix apps/desktop/ui ci
+      - run: node --expose-gc scripts/perf/memory-smoke.mjs
+
+  perf-api:
+    if: ${{ vars.PERF_BASE_URL != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: grafana/setup-k6-action@ffe7d7290dfa715e48c2ccc924d068444c94bde2
+      - run: k6 run tests/perf/api.k6.js --summary-export=.perf-results/api-summary.json
+        env:
+          BASE_URL: ${{ vars.PERF_BASE_URL }}
+
+  perf-db:
+    if: ${{ vars.PERF_DATABASE_URL != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - run: psql "${{ vars.PERF_DATABASE_URL }}" -f scripts/perf/db/check-pg-stat.sql

--- a/.perf-baselines/build-time.json
+++ b/.perf-baselines/build-time.json
@@ -1,0 +1,6 @@
+{
+  "buildMs": 0,
+  "capturedAt": "1970-01-01T00:00:00.000Z",
+  "ready": false,
+  "note": "placeholder baseline; do not enable enforced build perf gate until replaced with accepted measurements"
+}

--- a/.perf-baselines/bundle.json
+++ b/.perf-baselines/bundle.json
@@ -1,0 +1,15 @@
+{
+  "source": "vite",
+  "totalBytes": 169250,
+  "assets": {
+    "index-Bpp7DIAR.js": 165771,
+    "index-IaIZpIwz.css": 3073
+  },
+  "html": {
+    "index.html": 406
+  },
+  "capturedAt": "2026-04-12T05:30:15.047Z",
+  "ready": true,
+  "acceptedAt": "2026-04-12T05:30:15.162Z",
+  "acceptanceSource": "scripts/perf/refresh-baselines.mjs"
+}

--- a/scripts/perf/bundle-report.mjs
+++ b/scripts/perf/bundle-report.mjs
@@ -1,0 +1,71 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+function nextBundle() {
+  const manifestPath = ".next/build-manifest.json";
+  if (!existsSync(manifestPath)) return null;
+
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  const pages = manifest.pages || {};
+  const pageSizes = {};
+
+  for (const [route, files] of Object.entries(pages)) {
+    let total = 0;
+    for (const file of files) {
+      const full = path.join(".next", file.replace(/^\/?/, ""));
+      try {
+        total += statSync(full).size;
+      } catch {}
+    }
+    pageSizes[route] = total;
+  }
+
+  return {
+    source: "next",
+    totalBytes: Object.values(pageSizes).reduce((a, b) => a + b, 0),
+    pages: pageSizes,
+  };
+}
+
+function viteBundle() {
+  const distRoot = "apps/desktop/ui/dist";
+  const distAssets = path.join(distRoot, "assets");
+  if (!existsSync(distRoot)) return null;
+
+  const result = { source: "vite", totalBytes: 0, assets: {}, html: {} };
+  if (existsSync(distAssets)) {
+    for (const file of readdirSync(distAssets)) {
+      const full = path.join(distAssets, file);
+      try {
+        const size = statSync(full).size;
+        result.assets[file] = size;
+        result.totalBytes += size;
+      } catch {}
+    }
+  }
+
+  for (const file of readdirSync(distRoot)) {
+    const full = path.join(distRoot, file);
+    if (!file.endsWith(".html")) continue;
+    try {
+      const size = statSync(full).size;
+      result.html[file] = size;
+      result.totalBytes += size;
+    } catch {}
+  }
+  return result;
+}
+
+const run = async () => {
+  const report = nextBundle() || (await viteBundle()) || { source: "none", totalBytes: 0 };
+  mkdirSync(".perf-results", { recursive: true });
+  writeFileSync(
+    ".perf-results/bundle.json",
+    JSON.stringify({ ...report, capturedAt: new Date().toISOString() }, null, 2),
+  );
+};
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/perf/check-assets.sh
+++ b/scripts/perf/check-assets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# codex-os-managed
+max_bytes="${ASSET_MAX_BYTES:-350000}"
+dist_root="apps/desktop/ui/dist"
+dist_assets="$dist_root/assets"
+
+if [[ ! -d "$dist_root" ]]; then
+  echo "No built UI dist found at $dist_root; run the UI build before asset checks." >&2
+  exit 1
+fi
+
+fail=0
+checked=0
+while IFS= read -r file; do
+  checked=1
+  size=$(wc -c < "$file")
+  if (( size > max_bytes )); then
+    echo "Asset too large (>${max_bytes} bytes): $file"
+    fail=1
+  fi
+done < <(
+  {
+    if [[ -d "$dist_assets" ]]; then
+      find "$dist_assets" -type f ! -name "*.map"
+    fi
+    find "$dist_root" -maxdepth 1 -type f -name "*.html"
+  } | sort
+)
+
+if [[ "$checked" -eq 0 ]]; then
+  echo "No shipped UI asset files found under $dist_root; skipping asset size enforcement."
+fi
+
+exit $fail

--- a/scripts/perf/compare-metric.mjs
+++ b/scripts/perf/compare-metric.mjs
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+
+const [baselinePath, currentPath, metric, maxRatio] = process.argv.slice(2);
+if (!baselinePath || !currentPath || !metric || !maxRatio) {
+  console.error("usage: node compare-metric.mjs <baseline.json> <current.json> <metric> <max_ratio>");
+  process.exit(2);
+}
+
+const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+const current = JSON.parse(readFileSync(currentPath, "utf8"));
+const b = baseline[metric];
+const c = current[metric];
+
+if (typeof b !== "number" || typeof c !== "number") {
+  console.error(`Metric ${metric} missing or not numeric.`);
+  process.exit(2);
+}
+
+if (b === 0) {
+  const baselineZeroPayload = {
+    metric,
+    baseline: b,
+    current: c,
+    ratio: c === 0 ? 0 : null,
+    baseline_zero: true,
+  };
+  console.log(JSON.stringify(baselineZeroPayload, null, 2));
+  if (c > 0) {
+    console.error(`Regression on ${metric}: baseline is 0 and current is ${c}`);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+const ratio = (c - b) / b;
+console.log(JSON.stringify({ metric, baseline: b, current: c, ratio }, null, 2));
+
+if (ratio > Number(maxRatio)) {
+  console.error(
+    `Regression on ${metric}: ${(ratio * 100).toFixed(2)}% > ${(Number(maxRatio) * 100).toFixed(2)}%`,
+  );
+  process.exit(1);
+}

--- a/scripts/perf/measure-build-time.mjs
+++ b/scripts/perf/measure-build-time.mjs
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+const start = Date.now();
+const result = spawnSync("npm", ["--prefix", "apps/desktop/ui", "run", "build"], {
+  stdio: "inherit",
+});
+const end = Date.now();
+
+mkdirSync(".perf-results", { recursive: true });
+writeFileSync(
+  ".perf-results/build-time.json",
+  JSON.stringify(
+    {
+      buildMs: end - start,
+      capturedAt: new Date().toISOString(),
+      command: "npm --prefix apps/desktop/ui run build",
+    },
+    null,
+    2,
+  ),
+);
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1);
+}

--- a/scripts/perf/memory-smoke.mjs
+++ b/scripts/perf/memory-smoke.mjs
@@ -1,0 +1,40 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+
+if (typeof globalThis.gc !== "function") {
+  console.error("Run with --expose-gc.");
+  process.exit(1);
+}
+
+globalThis.gc();
+const before = process.memoryUsage().heapUsed;
+
+const allocations = [];
+for (let i = 0; i < 20_000; i += 1) {
+  allocations.push({ i, payload: `row-${i}`.repeat(4) });
+}
+
+globalThis.gc();
+const after = process.memoryUsage().heapUsed;
+const deltaMb = Number(((after - before) / (1024 * 1024)).toFixed(2));
+const maxDelta = Number(process.env.MEMORY_MAX_DELTA_MB || 10);
+
+mkdirSync(".perf-results", { recursive: true });
+writeFileSync(
+  ".perf-results/memory.json",
+  JSON.stringify(
+    {
+      heapBefore: before,
+      heapAfter: after,
+      deltaMb,
+      maxDeltaMb: maxDelta,
+      capturedAt: new Date().toISOString(),
+    },
+    null,
+    2,
+  ),
+);
+
+if (deltaMb > maxDelta) {
+  console.error(`Memory growth too high: ${deltaMb}MB > ${maxDelta}MB`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add the perf workflows and supporting scripts needed to validate the new bundle gate rollout
- commit the accepted bundle baseline while keeping build timing intentionally unready
- provide the minimal perf files needed for GitHub-side validation

## Why
This is a small validation PR to exercise the newly enabled bundle perf enforcement in GitHub Actions before broader rollout.