### PR TITLE
fix(opscinema): satisfy current clippy sort lint

### DIFF
--- a/apps/desktop/src-tauri/src/anchors/cache.rs
+++ b/apps/desktop/src-tauri/src/anchors/cache.rs
@@ -88,6 +88,6 @@ pub fn list_for_step(
         .into_iter()
         .filter(|a| a.step_id == step_id)
         .collect::<Vec<_>>();
-    anchors.sort_by(|a, b| a.anchor_id.cmp(&b.anchor_id));
+    anchors.sort_by_key(|a| a.anchor_id);
     Ok(anchors)
 }


### PR DESCRIPTION
## What

- Replaces the anchor cache comparator with `sort_by_key`.

## Why

- Current clippy treats the previous comparator as an `unnecessary_sort_by` warning, and the repo promotes warnings to errors in `make verify`.

## How

- Keeps the same anchor ordering behavior while using the clippy-preferred API.

## Testing

- `npm --prefix apps/desktop/ui ci`
- `make verify`
- `make package`

## Performance Impact

- None expected. Same ordering, no meaningful runtime impact.

## Risk / Notes

- Low risk one-line lint compatibility fix. This clears the OPscinema desktop happy-path verification blocker for the portfolio packet.

## Checklist

- [x] Tests pass
- [x] No new warnings
- [x] Documentation updated (not applicable)