### PR TITLE
ci: add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+  schedule:
+    - cron: "32 11 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze Rust and JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust, javascript-typescript
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## What

- Add a CodeQL workflow for Rust and JavaScript/TypeScript.
- Run on pull requests, pushes, scheduled scans, and manual dispatch.

## Why

GitHub code scanning is not configured on the default branch, so code-level findings are not being surfaced.

## How

Use CodeQL advanced setup with no-build analysis for Rust and JavaScript/TypeScript.

## Checklist

- [ ] Tests pass
- [ ] No new warnings
- [ ] Documentation updated (if applicable)